### PR TITLE
[FIX] DC Setup Fix

### DIFF
--- a/cloudshield/Cloud/templates/scripts/samba.tftpl
+++ b/cloudshield/Cloud/templates/scripts/samba.tftpl
@@ -86,6 +86,8 @@ echo "Administrator Password: ${dc_admin_password}"
 
 sudo systemctl status samba-ad-dc --no-pager
 
+sudo samba-tool user setpassword Administrator --newpassword="${dc_admin_password}"
+
 # ============================================================
 # STEP 6: Backend server does a check on the EC2 instance
 #         to make sure the installation process is completed


### PR DESCRIPTION
When setting up the domain controller we do not set the password to the Administrator correctly. This will prevent workstations from joining the server.