### PR TITLE
Correct directory creation in Dockerfile for Samba

### DIFF
--- a/docker/Dockerfile.samba_test
+++ b/docker/Dockerfile.samba_test
@@ -28,7 +28,8 @@ RUN echo "PubkeyAuthentication yes" >> /etc/ssh/sshd_config
 RUN echo "AuthorizedKeysFile .ssh/authorized_keys" >> /etc/ssh/sshd_config
 
 # Make directories for Samba
-RUN mkdir -p /var/lib/samba /var/log/samba /etc/samba
+RUN mkdir -p /var/lib/samba /var/log/samba /etc/sambaA
+RUN mkdir -p /srv/samba/shares/
 
 # Copy entrypoint script
 COPY docker/samba-test-docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh


### PR DESCRIPTION
Fix directory creation for Samba configuration.

Currently, the rpc infra_service.v1.InfraService/CreateSambaFileShare does not work because a directory is missing and never gets created.

The missing directory was added to the correct Dockerfile