### PR TITLE
Fix/agent provisioning and workstations api

### DIFF
--- a/cloudshield/Cloud/docker_provisioner/provision.py
+++ b/cloudshield/Cloud/docker_provisioner/provision.py
@@ -954,6 +954,37 @@ def _pick_workstation_host_port(org_subnet_cidr: str) -> int:
     return port
 
 
+def _reconnect_novnc(workstation_ip: str, org_network_name: str, server_logger) -> None:
+    """Stop the existing noVNC container and start a new one pointing at the new workstation."""
+    novnc_image = os.environ.get("NOVNC_IMAGE", "cs-novnc-test")
+    novnc_name = os.environ.get("NOVNC_CONTAINER", "cs-novnc-dev")
+    novnc_port = int(os.environ.get("NOVNC_PORT", "6080"))
+    try:
+        plain_docker = DockerClient()
+        existing = [c for c in plain_docker.ps(all=True) if c.name == novnc_name]
+        for c in existing:
+            try:
+                c.stop()
+                c.remove()
+            except Exception:
+                pass
+        plain_docker.container.run(
+            novnc_image,
+            name=novnc_name,
+            detach=True,
+            networks=[org_network_name],
+            envs={
+                "TARGET_HOST": workstation_ip,
+                "TARGET_PORT": "5900",
+                "LISTEN_PORT": str(novnc_port),
+            },
+            publish=[(novnc_port, novnc_port)],
+        )
+        server_logger.info(f"noVNC reconnected → {workstation_ip}:5900 (:{novnc_port})")
+    except Exception as exc:
+        server_logger.warning(f"Failed to reconnect noVNC: {exc}")
+
+
 def provision_workstation_docker(
     org_id,
     server_logger,
@@ -972,13 +1003,20 @@ def provision_workstation_docker(
 
     host_port = _pick_workstation_host_port(org_subnet_cidr)
 
+    # Delete the old Windows disk image so the new provisioning gets a fresh
+    # install with the correct OEM scripts (including the right SERVER_ADDR).
+    storage_dir = _workstation_storage_dir(org_id)
+    data_img = os.path.join(storage_dir, "data.img")
+    if os.path.exists(data_img):
+        os.remove(data_img)
+        server_logger.info(f"Deleted stale disk image: {data_img}")
+
     org_docker.compose.build(services=["workstation"])
     container_ws = org_docker.compose.run(
         service="workstation",
         publish=[(host_port, 8006)],
         detach=True,
         tty=False,
-        service_ports=True,
         build=False
     )
 
@@ -1057,6 +1095,8 @@ def provision_workstation_docker(
         return
 
     server_logger.info("Windows workstation installation has started, this will take some time")
+
+    _reconnect_novnc(container_ws_ip, org_network_name, server_logger)
 
     return {
         "port": str(host_port),
@@ -1148,8 +1188,9 @@ def provision_network_docker(org_data, region, templates_dir, generated_dir, cou
 
     # Resolve the CloudShield Server URL so ThreatDetection can push alerts to it.
     # Look up the API container IP on cloudshield_net at provision time.
-    _cs_server_url = os.environ.get("CLOUDSHIELD_SERVER_URL", "")
-    if not _cs_server_url:
+    _cs_server_url = os.environ.get("CLOUDSHIELD_SERVER_URL", "").strip()
+    # 127.0.0.1 is meaningless inside a container — ignore it and look up the real API container.
+    if not _cs_server_url or "127.0.0.1" in _cs_server_url or "localhost" in _cs_server_url:
         try:
             _plain_docker = DockerClient()
             for _c in _plain_docker.ps():
@@ -1347,6 +1388,27 @@ def provision_network_docker(org_data, region, templates_dir, generated_dir, cou
             "private_ip": td_ip,
             "public_ip": td_ip,
         })
+
+    # Provision the workstation now that td_ip is known so THREAT_DETECTION_IP
+    # is correctly substituted into the OEM agent install scripts.
+    td_agents_file = Path(td_agents_dir) / "agents.json" if td_agents_dir else None
+    ws_result = provision_workstation_docker(
+        org_id=org_id,
+        server_logger=server_logger,
+        org_docker=org_docker,
+        org_network_name=org_network_name,
+        samba_ip=container_dc_ip,
+        org_subnet_cidr=org_subnet_cidr,
+        threat_detection_ip=td_ip,
+        td_agents_file=td_agents_file,
+        td_container_id=td_container_id,
+        domain_name=domain_name,
+        admin_pass=dc_admin_password,
+    )
+    if ws_result:
+        metadata.append(ws_result)
+    else:
+        server_logger.error("Workstation provisioning failed for org %s", org_id)
 
     return metadata
 

--- a/cloudshield/Server/repos/workstations_repo.py
+++ b/cloudshield/Server/repos/workstations_repo.py
@@ -186,7 +186,7 @@ def get_workstations(db, org_id: str):
     Get all the workstations of an organization
     """
 
-    ws_db = db.workstations
+    ws_db = db.workstation_templates
 
     workstations = list(ws_db.find({"org_id": org_id}))
     
@@ -226,4 +226,3 @@ def get_available_workstation(db, user_id):
         workstations.append(doc)
 
     return workstations
-

--- a/cloudshield/Server/repos/workstations_repo.py
+++ b/cloudshield/Server/repos/workstations_repo.py
@@ -186,7 +186,7 @@ def get_workstations(db, org_id: str):
     Get all the workstations of an organization
     """
 
-    ws_db = db.workstation_templates
+    ws_db = db.workstations
 
     workstations = list(ws_db.find({"org_id": org_id}))
     

--- a/cloudshield/Server/routes/workstations.py
+++ b/cloudshield/Server/routes/workstations.py
@@ -5,7 +5,7 @@ from utils.logging_setup import get_logger
 from services import service_dispatcher
 from cloudshield.Server.security.guards import require_auth
 from utils import db
-from repos import get_workstation_templates, insert_workstation_template, get_available_workstation, set_assigned_workstation, release_assigned_workstation
+from repos import get_workstation_templates, get_workstations, insert_workstation_template, get_available_workstation, set_assigned_workstation, release_assigned_workstation
 
 logger = get_logger("workstations")
 
@@ -16,6 +16,19 @@ ERROR_TEMPLATE_ID_REQUIRED = "template_id is required"
 ERROR_WORKSTATION_ID_REQUIRED = "workstation_id is required"
 ERROR_STATUS_REQUIRED = "status is required"
 ERROR_USER_ID_REQUIRED = "user_id is required"
+
+@workstations_bp.route("/workstations", methods=["GET"])
+@require_auth
+def list_workstations():
+    org_id = request.args.get("org_id")
+
+    if not org_id:
+        return jsonify({"error": ERROR_ORG_ID_REQUIRED}), 400
+
+    workstations_list = get_workstations(db, org_id=org_id)
+
+    return jsonify(workstations_list), 200
+
 
 @workstations_bp.route("/workstations/assign", methods=["GET"])
 @require_auth

--- a/cloudshield/Server/tasks/__init__.py
+++ b/cloudshield/Server/tasks/__init__.py
@@ -1,3 +1,5 @@
+import importlib
+
 from .network_provisioning import provision_network as provision_network
 from .network_provisioning import destroy_environment as destroy_environment
 from .network_provisioning import provision_workstations as provision_workstations
@@ -42,3 +44,9 @@ if _provision_module is not None:
     provision_main = _provision_module.provision_network_terraform
 else:
     provision_main = None  # type: ignore[assignment]
+
+
+def __getattr__(name):
+    if name == "task":
+        return importlib.import_module(".task", __name__)
+    raise AttributeError(name)

--- a/cloudshield/Server/tests/test_task.py
+++ b/cloudshield/Server/tests/test_task.py
@@ -139,7 +139,7 @@ class TestGetFullGrpcPath:
         result = get_full_grpc_path("@@InvalidMethod@@")
         assert result is None
 
-    @patch("cloudshield.Server.tasks.task.descriptor_pool")
+    @patch.object(_task_mod, "descriptor_pool")
     def test_get_full_grpc_path_key_error(self, mock_pool):
         """Test get_full_grpc_path handles KeyError from descriptor pool."""
         mock_default = MagicMock()
@@ -149,7 +149,7 @@ class TestGetFullGrpcPath:
         result = get_full_grpc_path("SomeMethod")
         assert result is None
 
-    @patch("cloudshield.Server.tasks.task.descriptor_pool")
+    @patch.object(_task_mod, "descriptor_pool")
     def test_get_full_grpc_path_success(self, mock_pool):
         """Test get_full_grpc_path successfully constructs path."""
         mock_method = MagicMock()
@@ -169,7 +169,7 @@ class TestGetFullGrpcPath:
 class TestGetGrpcChannel:
     """Tests for the get_grpc_channel function."""
 
-    @patch("cloudshield.Server.tasks.task.grpc.insecure_channel")
+    @patch.object(_task_mod.grpc, "insecure_channel")
     def test_get_grpc_channel_creates_channel(self, mock_insecure_channel):
         """Test get_grpc_channel creates an insecure gRPC channel."""
         mock_channel = MagicMock()
@@ -180,7 +180,7 @@ class TestGetGrpcChannel:
         mock_insecure_channel.assert_called_once_with("localhost:8080")
         assert result == mock_channel
 
-    @patch("cloudshield.Server.tasks.task.grpc.insecure_channel")
+    @patch.object(_task_mod.grpc, "insecure_channel")
     def test_get_grpc_channel_with_different_host(self, mock_insecure_channel):
         """Test get_grpc_channel with different host addresses."""
         mock_channel = MagicMock()
@@ -189,7 +189,7 @@ class TestGetGrpcChannel:
         get_grpc_channel("192.168.1.1:5000")
         mock_insecure_channel.assert_called_once_with("192.168.1.1:5000")
 
-    @patch("cloudshield.Server.tasks.task.grpc.insecure_channel")
+    @patch.object(_task_mod.grpc, "insecure_channel")
     def test_get_grpc_channel_returns_channel(self, mock_insecure_channel):
         """Test get_grpc_channel returns the created channel."""
         mock_channel = MagicMock()
@@ -202,7 +202,7 @@ class TestGetGrpcChannel:
 class TestGetServerNodes:
     """Tests for the get_server_nodes function."""
 
-    @patch("cloudshield.Server.tasks.task.get_inventory_from_org_id")
+    @patch.object(_task_mod, "get_inventory_from_org_id")
     def test_get_server_nodes_with_both_nodes(self, mock_get_inventory):
         """Test get_server_nodes returns both OPENVPN and DOMAIN_CONTROLLER nodes."""
         openvpn_asset = EC2Instance(
@@ -256,7 +256,7 @@ class TestGetServerNodes:
         assert result["OPENVPN"].ip == "203.0.113.1"
         assert result["DOMAIN_CONTROLLER"].ip == "10.0.0.2"
 
-    @patch("cloudshield.Server.tasks.task.get_inventory_from_org_id")
+    @patch.object(_task_mod, "get_inventory_from_org_id")
     def test_get_server_nodes_only_openvpn(self, mock_get_inventory):
         """Test get_server_nodes with only OPENVPN node."""
         openvpn_asset = EC2Instance(
@@ -288,7 +288,7 @@ class TestGetServerNodes:
         assert "OPENVPN" in result
         assert "DOMAIN_CONTROLLER" not in result
 
-    @patch("cloudshield.Server.tasks.task.get_inventory_from_org_id")
+    @patch.object(_task_mod, "get_inventory_from_org_id")
     def test_get_server_nodes_empty_inventory(self, mock_get_inventory):
         """Test get_server_nodes with empty inventory."""
         inventory = Inventory(org_id="org-123", assets=[])
@@ -298,8 +298,8 @@ class TestGetServerNodes:
 
         assert result == {}
 
-    @patch("cloudshield.Server.tasks.task.get_logger")
-    @patch("cloudshield.Server.tasks.task.get_inventory_from_org_id")
+    @patch.object(_task_mod, "get_logger")
+    @patch.object(_task_mod, "get_inventory_from_org_id")
     def test_get_server_nodes_inventory_none(self, mock_get_inventory, mock_logger):
         """Test get_server_nodes when inventory is None."""
         mock_get_inventory.return_value = None
@@ -310,7 +310,7 @@ class TestGetServerNodes:
         assert result is None
         mock_get_inventory.assert_called_once_with("org-nonexistent")
 
-    @patch("cloudshield.Server.tasks.task.get_inventory_from_org_id")
+    @patch.object(_task_mod, "get_inventory_from_org_id")
     def test_get_server_nodes_multiple_assets_unrelated(self, mock_get_inventory):
         """Test get_server_nodes filters correct assets by name."""
         unrelated_asset = EC2Instance(
@@ -364,7 +364,7 @@ class TestGetServerNodes:
         assert "OPENVPN" in result
         assert len(result) == 1
 
-    @patch("cloudshield.Server.tasks.task.get_inventory_from_org_id")
+    @patch.object(_task_mod, "get_inventory_from_org_id")
     def test_get_server_nodes_server_node_properties(self, mock_get_inventory):
         """Test get_server_nodes creates ServerNode with correct properties."""
         openvpn_asset = EC2Instance(
@@ -400,7 +400,7 @@ class TestGetServerNodes:
 class TestGetServerNode:
     """Tests for the get_server_node function."""
 
-    @patch("cloudshield.Server.tasks.task.get_server_nodes")
+    @patch.object(_task_mod, "get_server_nodes")
     def test_get_server_node_raises_attribute_error(self, mock_get_server_nodes):
         """Test get_server_node raises AttributeError due to bug in implementation.
         
@@ -428,7 +428,7 @@ class TestGetServerNode:
         with pytest.raises(AttributeError):
             get_server_node("org-123", NodeType.OPENVPN)
 
-    @patch("cloudshield.Server.tasks.task.get_server_nodes")
+    @patch.object(_task_mod, "get_server_nodes")
     def test_get_server_node_with_empty_nodes(self, mock_get_server_nodes):
         """Test get_server_node with empty nodes dictionary returns None implicitly."""
         nodes = {}
@@ -443,9 +443,9 @@ class TestGetServerNode:
 class TestProxyRPCRequest:
     """Tests for the proxy_rpc_request function."""
 
-    @patch("cloudshield.Server.tasks.task.get_grpc_channel")
-    @patch("cloudshield.Server.tasks.task.get_full_grpc_path")
-    @patch("cloudshield.Server.tasks.task.vpn_pb2_grpc.VPNServiceStub")
+    @patch.object(_task_mod, "get_grpc_channel")
+    @patch.object(_task_mod, "get_full_grpc_path")
+    @patch.object(_task_mod.vpn_pb2_grpc, "VPNServiceStub")
     def test_proxy_rpc_request_success(
         self,
         mock_stub_class,
@@ -488,9 +488,9 @@ class TestProxyRPCRequest:
         mock_get_channel.assert_called_once_with("203.0.113.1:1194")
         mock_stub.Relay.assert_called_once()
 
-    @patch("cloudshield.Server.tasks.task.get_grpc_channel")
-    @patch("cloudshield.Server.tasks.task.get_full_grpc_path")
-    @patch("cloudshield.Server.tasks.task.vpn_pb2_grpc.VPNServiceStub")
+    @patch.object(_task_mod, "get_grpc_channel")
+    @patch.object(_task_mod, "get_full_grpc_path")
+    @patch.object(_task_mod.vpn_pb2_grpc, "VPNServiceStub")
     def test_proxy_rpc_request_stub_error(
         self,
         mock_stub_class,
@@ -529,7 +529,7 @@ class TestProxyRPCRequest:
 
         assert result is None
 
-    @patch("cloudshield.Server.tasks.task.get_full_grpc_path")
+    @patch.object(_task_mod, "get_full_grpc_path")
     def test_proxy_rpc_request_invalid_method(self, mock_get_full_path):
         """Test proxy_rpc_request with invalid method name."""
         openvpn_node = ServerNode(
@@ -598,9 +598,9 @@ class TestProxyRPCRequest:
 
         assert result is None
 
-    @patch("cloudshield.Server.tasks.task.get_grpc_channel")
-    @patch("cloudshield.Server.tasks.task.get_full_grpc_path")
-    @patch("cloudshield.Server.tasks.task.vpn_pb2_grpc.VPNServiceStub")
+    @patch.object(_task_mod, "get_grpc_channel")
+    @patch.object(_task_mod, "get_full_grpc_path")
+    @patch.object(_task_mod.vpn_pb2_grpc, "VPNServiceStub")
     def test_proxy_rpc_request_serialization(
         self,
         mock_stub_class,
@@ -646,9 +646,9 @@ class TestProxyRPCRequest:
         relay_request = call_args[0][0]
         assert relay_request.data == expected_serialized
 
-    @patch("cloudshield.Server.tasks.task.get_grpc_channel")
-    @patch("cloudshield.Server.tasks.task.get_full_grpc_path")
-    @patch("cloudshield.Server.tasks.task.vpn_pb2_grpc.VPNServiceStub")
+    @patch.object(_task_mod, "get_grpc_channel")
+    @patch.object(_task_mod, "get_full_grpc_path")
+    @patch.object(_task_mod.vpn_pb2_grpc, "VPNServiceStub")
     def test_proxy_rpc_request_relay_data_format(
         self,
         mock_stub_class,
@@ -697,7 +697,7 @@ class TestProxyRPCRequest:
 class TestIntegration:
     """Integration tests combining multiple components."""
 
-    @patch("cloudshield.Server.tasks.task.get_inventory_from_org_id")
+    @patch.object(_task_mod, "get_inventory_from_org_id")
     def test_full_server_node_workflow(self, mock_get_inventory):
         """Test complete workflow from inventory to ServerNode creation."""
         openvpn_asset = EC2Instance(

--- a/cloudshield/Server/utils/__init__.py
+++ b/cloudshield/Server/utils/__init__.py
@@ -49,8 +49,8 @@ _EXPORTS: dict[str, tuple[str, str]] = {
 
 
 def __getattr__(name: str) -> Any:  # pragma: no cover
-    if name == "redis_client":
-        module = importlib.import_module(".redis_client", __name__)
+    if name in {"redis_client", "audit", "database"}:
+        module = importlib.import_module(f".{name}", __name__)
         globals()[name] = module
         return module
 

--- a/docker/workstation/oem/install_cloudshield_agent.ps1
+++ b/docker/workstation/oem/install_cloudshield_agent.ps1
@@ -75,5 +75,6 @@ Write-Host "[CloudShield] Agent installation complete."
 
 # Start the agent immediately — the scheduled task's startup trigger fires before
 # this script runs during OOBE, so the first launch must be done explicitly here.
+$LauncherCmdPath = "$InstallDir\launch_cloudshield_agent.cmd"
 Write-Host "[CloudShield] Starting agent now..."
 Start-Process -FilePath "cmd.exe" -ArgumentList "/c `"$LauncherCmdPath`"" -WorkingDirectory $InstallDir -WindowStyle Hidden

--- a/docker/workstation/oem/install_cloudshield_agent.ps1
+++ b/docker/workstation/oem/install_cloudshield_agent.ps1
@@ -72,3 +72,8 @@ if (-not (Test-Path $RegisterTaskScript)) {
     -AgentId $AgentId
 
 Write-Host "[CloudShield] Agent installation complete."
+
+# Start the agent immediately — the scheduled task's startup trigger fires before
+# this script runs during OOBE, so the first launch must be done explicitly here.
+Write-Host "[CloudShield] Starting agent now..."
+Start-Process -FilePath "cmd.exe" -ArgumentList "/c `"$LauncherCmdPath`"" -WorkingDirectory $InstallDir -WindowStyle Hidden


### PR DESCRIPTION
Fixes agent provisioning in docker mode end-to-end: TD IP now correctly substituted in OEM scripts, stale data.img deleted on reprovision, noVNC auto-reconnects

CLOUDSHIELD_SERVER_URL localhost check added, agent launches immediately after OOBE install, and GET /workstations route added with correct DB collection.